### PR TITLE
Allow bind_dn to be templated

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -1,6 +1,7 @@
 ldap:
   host_url: ldap://org.example:389
-  bind_dn: "cn=readonly,dc=org,dc=example"
+  bind_dn: "cn=%s,dc=org,dc=example"
+  bind_username: readonly  # Will be substituted into `bind_dn`
   bind_password: readonly
   group_attribute: memberOf
   base_dn: "ou=users,dc=org,dc=example"

--- a/internal/directory_ldap.go
+++ b/internal/directory_ldap.go
@@ -32,9 +32,16 @@ func CNToGroupName(cn string) string {
 // GenerateLdapConfig generates an LDAP config object from external config
 // files or environment variables.
 func GenerateLdapConfig() LdapConfig {
+	// Dynamically generate the bind dn
+	bind_dn := viper.GetString("ldap.bind_dn")
+	user := viper.GetString("ldap.bind_username")
+	if strings.Contains(bind_dn, "%s") {
+		bind_dn = fmt.Sprintf(bind_dn, user)
+	}
+
 	return LdapConfig{
 		HostURL:        viper.GetString("ldap.host_url"),
-		BindDN:         viper.GetString("ldap.bind_dn"),
+		BindDN:         bind_dn,
 		BindPassword:   viper.GetString("ldap.bind_password"),
 		GroupAttribute: viper.GetString("ldap.group_attribute"),
 		BaseDN:         viper.GetString("ldap.base_dn"),


### PR DESCRIPTION
Resolves #8 

Lets users run queries by providing only `YODEL_BIND_USERNAME` and `YODEL_BIND_PASSWORD` (Given they have a `config.yaml` which is correctly configured to point at their LDAP server)

This is pretty backwards compatible, substitution will not happen if there's no "%s" in the `bind_dn`.